### PR TITLE
This must prevent memory leaking

### DIFF
--- a/gzip_ecap_vb_stop_on_done_v1.patch
+++ b/gzip_ecap_vb_stop_on_done_v1.patch
@@ -1,0 +1,20 @@
+--- src/adapter_gzip.cc		Wed Jun  8 21:21:10 2016
++++ src/adapter_gzip.cc		Sat Jun 18 22:32:09 2016
+@@ -548,7 +548,7 @@
+ 	
+ 
+ 	Must(receivingVb == opOn);
+-	receivingVb = opComplete;
++	stopVb();
+ 	if (sendingAb == opOn) {
+ 		hostx->noteAbContentDone(atEnd);
+ 		sendingAb = opComplete;
+@@ -611,7 +611,7 @@
+ // if the host does not know that already
+ void Adapter::Xaction::stopVb() {
+ 	if (receivingVb == opOn) {
+-		hostx->vbStopMaking();
++		hostx->vbStopMaking(); // we will not call vbContent() any more
+ 		receivingVb = opComplete;
+ 	} else {
+ 		// we already got the entire body or refused it earlier


### PR DESCRIPTION
Tell the host application when we no longer need virgin body so that the host application can get rid of allocated resources and possibly terminate the transaction.
This must prevent memory leaking during adapter runs.
Based on vb-stop-on-done.patch  by Alex Rousskov from here: https://answers.launchpad.net/ecap/+question/295319

It must fix latest memory issue.